### PR TITLE
Fix showing incorrect error message

### DIFF
--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -10,5 +10,5 @@ const errorMessages = {
 };
 
 export const displayError = (error: keyof typeof errorMessages) => {
-    return window.showErrorMessage(errorMessages.noEmail);
+    return window.showErrorMessage(errorMessages[error]);
 };


### PR DESCRIPTION
The `noEmail`  error message is always shown regardless of the real error. 
This might also fix some cases in this [issue](https://github.com/VaibhavAcharya/code-gpt/issues/6).